### PR TITLE
Implement displayMobileView function

### DIFF
--- a/src/components/WindowSize/index.js
+++ b/src/components/WindowSize/index.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+
+export const getWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+
+  const handleResize = () => {
+    setWindowSize({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    });
+  };
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.addEventListener("resize", handleResize);
+      handleResize();
+      return () => window.removeEventListener("resize", handleResize);
+    }
+  }, []);
+  return windowSize;
+};

--- a/src/screens/Index/IndexPage.jsx
+++ b/src/screens/Index/IndexPage.jsx
@@ -9,7 +9,9 @@ const IndexPage = () => (
   <>
     <div className={classes.general}>
       <h1 className={classes.centerText}>HOPE SUSTAINS LIFE</h1>
-	  <p className={classes.centered}>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <p className={classes.centered}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+      </p>
       <Row>
         <Col></Col>
         <Col md="auto">

--- a/utils/screen.js
+++ b/utils/screen.js
@@ -1,0 +1,10 @@
+import { getWindowSize } from "../src/components/WindowSize";
+
+/**
+ * Because Next.js does SSR, it does not have access to Window and Document APIs.
+ * NOTE: any component that calls this method should be dynamically imported.
+ * This will allow it to capture the client's browser data
+ */
+export const displayMobileView = () => {
+  return getWindowSize().width < 600;
+};


### PR DESCRIPTION
In SSR we cannot directly retrieve window size.
Create a wrapper component that initializes the window dimension upon rendering on the client-side.