### PR TITLE
The learn-more page on the home page redirects to the our work subpage.

### DIFF
--- a/src/screens/Index/IndexPage.jsx
+++ b/src/screens/Index/IndexPage.jsx
@@ -231,7 +231,7 @@ const IndexPage = () => {
           >
             Read about what we're working on and how we plan to do it.
           </Card.Text>
-          <Link href={urls.pages.ourStory}>
+          <Link href={urls.pages.ourWork}>
             <Button
               className={mobileView ? classes.mobileViewMore : classes.viewMore}
             >


### PR DESCRIPTION
Just a small change to fix the redirect link on the learn more button. The rest of the changes for link redirects are completed through Firebase.